### PR TITLE
add yabgp

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,9 @@ Templating language for Python and excellent library to use for generating netwo
 - [beka](https://github.com/samrussell/beka)  
 A Python BGP Speaker.
 
+- [yabgp](https://github.com/smartbgp/yabgp)
+YABGP is a Yet Another Python implementation for BGP Protocol.
+
 ### Examples
 - [Cisco gRPC Connection Libraries](https://github.com/cisco-grpc-connection-libs)  
 Example repositories on how to use gRPC in Python, NodeJS, etc. for the IOS-XR end node.


### PR DESCRIPTION
YABGP is a yet another Python implementation for BGP Protocol. It can be used to establish BGP connections with all kinds of routers (include real Cisco/HuaWei/Juniper routers and some router simulators) and receive/parse BGP messages for future analysis.

Support sending BGP messages(route refresh/update) to the peer through RESTful API. YABGP can't send any BGP update messages by itself, it's just a agent, so there can be many agents and they can be controlled by a contoller.